### PR TITLE
Add missing required fields to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -2,3 +2,7 @@ name=HC-SR04
 version=1.0.0
 author=Lenon Marcel
 maintainer=Lenon Marcel
+sentence=For the HC-SR04 ultrasonic distance sensor.
+paragraph=
+category=Sensors
+url=https://github.com/lenon/HC-SR04


### PR DESCRIPTION
When a required field is missing from library.properties the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format